### PR TITLE
신뢰할 수 없는 시간 값 취약점 픽스

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
@@ -40,8 +40,6 @@ public class CredentialManager {
     private boolean mEnable = false;
     private int mTime = 30;
 
-
-
     // 마지막 인증 통과 시점을 저장하는 변수
     private long mLastCheckPass = 0;
     /*
@@ -67,7 +65,7 @@ public class CredentialManager {
      * 비정상적인 동작이므로 토큰 생성을 막는다
      */
     public boolean check() {
-        if (!mEnable || new Date().getTime() - mLastCheckPass< mTime * DateUtils.SECOND_IN_MILLIS && (mLastCheckPass  < new Date().getTime())) {
+        if (!mEnable || new Date().getTime() - mLastCheckPass < mTime * DateUtils.SECOND_IN_MILLIS && (mLastCheckPass  < new Date().getTime())) {
             return true;
         }
         else {

--- a/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
@@ -40,6 +40,8 @@ public class CredentialManager {
     private boolean mEnable = false;
     private int mTime = 30;
 
+
+
     // 마지막 인증 통과 시점을 저장하는 변수
     private long mLastCheckPass = 0;
     /*
@@ -61,10 +63,13 @@ public class CredentialManager {
 
     /*
      * OTP 접근 가능 여부를 검사
+     * 기기시간을 과거로 돌렸을때 저장된 마지막 시간값 보다 현재 시간이 빠를시에,
+     * 비정상적인 동작이므로 토큰 생성을 막는다. 
      */
     public boolean check() {
-        if (!mEnable || new Date().getTime() - mLastCheckPass < mTime * DateUtils.SECOND_IN_MILLIS)
+        if (!mEnable || new Date().getTime() - mLastCheckPass< mTime * DateUtils.SECOND_IN_MILLIS && (mLastCheckPass  < new Date().getTime())) {
             return true;
+        }
         else {
             Intent intent = mKeyguardManager.createConfirmDeviceCredentialIntent(null,null);
             ((Activity) mAppContext).startActivityForResult(intent, CREDENTIAL_CHECK);

--- a/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/CredentialManager.java
@@ -64,7 +64,7 @@ public class CredentialManager {
     /*
      * OTP 접근 가능 여부를 검사
      * 기기시간을 과거로 돌렸을때 저장된 마지막 시간값 보다 현재 시간이 빠를시에,
-     * 비정상적인 동작이므로 토큰 생성을 막는다. 
+     * 비정상적인 동작이므로 토큰 생성을 막는다
      */
     public boolean check() {
         if (!mEnable || new Date().getTime() - mLastCheckPass< mTime * DateUtils.SECOND_IN_MILLIS && (mLastCheckPass  < new Date().getTime())) {


### PR DESCRIPTION
제가 실수로 커밋을 두번해서 두번 올라갔는데 실제로는 한번만 수정했습니다.
if (!mEnable || new Date().getTime() - mLastCheckPass< mTime * DateUtils.SECOND_IN_MILLIS )
기존의 이 부분에서
if (!mEnable || new Date().getTime() - mLastCheckPass< mTime * DateUtils.SECOND_IN_MILLIS && (mLastCheckPass < new Date().getTime())
이렇게 마지막 체크값이 현재 시간보다 작지 않을 경우에는 기기 시간을 조작한것이 되므로 토큰 생성을 막았습니다.